### PR TITLE
PYMT-1336 Class finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "php": ">=7.3",
     "ext-json": "*",
     "cebe/php-openapi": "^1.2",
+    "eoneopay/utils": "^0.2.10",
     "phpdocumentor/reflection-docblock": "^4.3",
     "symfony/property-info": "^4.3"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1912abedee7c7f1dcba3ed94e0299047",
+    "content-hash": "0d60e432d4133b9fb6b309ecba31138e",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -67,6 +67,66 @@
                 "openapi"
             ],
             "time": "2019-06-28T13:51:20+00:00"
+        },
+        {
+            "name": "eoneopay/utils",
+            "version": "v0.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/loyaltycorp/utils.git",
+                "reference": "6fa07260b15036e414401f87a75fa9c2d0081b72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/loyaltycorp/utils/zipball/6fa07260b15036e414401f87a75fa9c2d0081b72",
+                "reference": "6fa07260b15036e414401f87a75fa9c2d0081b72",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.6",
+                "eoneopay/standards": "dev-master",
+                "ext-bcmath": "*",
+                "illuminate/http": "^5.8",
+                "illuminate/routing": "^5.8",
+                "illuminate/support": "^5.5",
+                "indigophp/doctrine-annotation-autoload": "^0.1.0",
+                "mockery/mockery": "^1.0",
+                "phpmd/phpmd": "^2.6",
+                "phpstan/phpstan": "^0.11",
+                "phpunit/phpunit": "^7.0",
+                "roave/security-advisories": "dev-master",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "suggest": {
+                "doctrine/annotations": "Required to use the annotation reader",
+                "ext-bcmath": "To use the Math service",
+                "illuminate/support": "Required to use the configuration service provider in Lumen",
+                "indigophp/doctrine-annotation-autoload": "Recommended to autoload custom doctrine annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "EoneoPay\\Utils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Utility and helper classes",
+            "keywords": [
+                "eoneopay",
+                "helpers",
+                "utilities"
+            ],
+            "time": "2019-08-17T14:04:34+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
         -
             message: '#Variable property access on cebe\\openapi\\spec\\PathItem\.#'
             path: src/Generator/RouteConverter.php
+        -
+            message: '#Property Tests\\LoyaltyCorp\\ApiDocumenter\\Unit\\Generator\\Fixtures\\PublicProperties::\$typeless has no typehint specified\.#'
+            path: tests/Unit/Generator/Fixtures/PublicProperties.php

--- a/src/Generator/ClassFinder.php
+++ b/src/Generator/ClassFinder.php
@@ -7,22 +7,11 @@ use DateTime as BaseDatetime;
 use DateTimeInterface;
 use EoneoPay\Utils\DateTime;
 use EoneoPay\Utils\UtcDateTime;
-use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
-use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use LoyaltyCorp\ApiDocumenter\Generator\Interfaces\ClassFinderInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
-/**
- * The class finder is used to traverse a graph of object classes and return
- * a list of all classes that were found during that traversal.
- *
- * It is used to have a list of all objects that may be returned by the API
- * so that Schema objects can be built for any possible returned values.
- *
- * The class can be configured to skip objects that should be considered as
- * value objects (and that the serialiser will turn into scalar objects).
- */
-final class ClassFinder
+final class ClassFinder implements ClassFinderInterface
 {
     /**
      * @var \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface
@@ -37,41 +26,19 @@ final class ClassFinder
     /**
      * Constructor.
      *
+     * @param \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface $propertyInfo
      * @param string[] $skipClasses
      */
     public function __construct(
+        PropertyInfoExtractorInterface $propertyInfo,
         array $skipClasses
     ) {
-        // This is constructed and not injected because it is not intended to be customisable.
-        // The extractors are configured explicitly for the purposes of finding classes.
-        $phpDocExtractor = new PhpDocExtractor();
-        $reflectionExtractor = new ReflectionExtractor(
-            null,
-            null,
-            null,
-            true,
-            ReflectionExtractor::ALLOW_PRIVATE |
-                ReflectionExtractor::ALLOW_PROTECTED |
-                ReflectionExtractor::ALLOW_PUBLIC
-        );
-
-        $this->propertyInfo = new PropertyInfoExtractor(
-            [$reflectionExtractor],
-            [$phpDocExtractor, $reflectionExtractor],
-            [$phpDocExtractor],
-            [],
-            []
-        );
-
+        $this->propertyInfo = $propertyInfo;
         $this->skipClasses = $skipClasses;
     }
 
     /**
-     * Extracts classes out of an array of class strings.
-     *
-     * @param string[] $classes
-     *
-     * @return string[]
+     * {@inheritdoc}
      */
     public function extract(array $classes): array
     {

--- a/src/Generator/ClassFinder.php
+++ b/src/Generator/ClassFinder.php
@@ -10,13 +10,12 @@ use EoneoPay\Utils\UtcDateTime;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 final class ClassFinder
 {
     /**
-     * @var PropertyInfoExtractorInterface
+     * @var \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface
      */
     private $propertyInfo;
 
@@ -81,28 +80,26 @@ final class ClassFinder
      * @param string[] $found
      * @param string $class
      *
-     * @return string[]
+     * @return void
      */
-    private function extractClasses(array &$found, string $class): array
+    private function extractClasses(array &$found, string $class): void
     {
         // If what we've found isnt a real class there is nothing to find.
         if (\class_exists($class) === false &&
             \interface_exists($class) === false) {
-            return [];
+            return;
         }
 
         // We've already seen the class or it should be skipped based on configuration.
         if (\in_array($class, $found, true) === true ||
             $this->shouldSkip($class)
         ) {
-            return [];
+            return;
         }
 
         $found[] = $class;
 
         $properties = $this->getProperties($class);
-
-        $discovered = [];
 
         foreach ($properties as $property) {
             $types = $this->propertyInfo->getTypes($class, $property);
@@ -124,14 +121,12 @@ final class ClassFinder
                 $this->extractClasses($found, $foundClass);
             }
         }
-
-        return $discovered;
     }
 
     /**
      * Finds a class for a type, if one exists.
      *
-     * @param Type $type
+     * @param \Symfony\Component\PropertyInfo\Type $type
      *
      * @return string|null
      */

--- a/src/Generator/ClassFinder.php
+++ b/src/Generator/ClassFinder.php
@@ -1,0 +1,213 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Generator;
+
+use DateTime as BaseDatetime;
+use DateTimeInterface;
+use EoneoPay\Utils\DateTime;
+use EoneoPay\Utils\UtcDateTime;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+final class ClassFinder
+{
+    /**
+     * @var PropertyInfoExtractorInterface
+     */
+    private $propertyInfo;
+
+    /**
+     * @var string[]
+     */
+    private $skipClasses;
+
+    /**
+     * Constructor.
+     *
+     * @param string[] $skipClasses
+     */
+    public function __construct(
+        array $skipClasses
+    ) {
+        // This is constructed and not injected because it is not intended to be customisable.
+        // The extractors are configured explicitly for the purposes of finding classes.
+        $phpDocExtractor = new PhpDocExtractor();
+        $reflectionExtractor = new ReflectionExtractor(
+            null,
+            null,
+            null,
+            true,
+            ReflectionExtractor::ALLOW_PRIVATE |
+                ReflectionExtractor::ALLOW_PROTECTED |
+                ReflectionExtractor::ALLOW_PUBLIC
+        );
+
+        $this->propertyInfo = new PropertyInfoExtractor(
+            [$reflectionExtractor],
+            [$phpDocExtractor, $reflectionExtractor],
+            [$phpDocExtractor],
+            [],
+            []
+        );
+
+        $this->skipClasses = $skipClasses;
+    }
+
+    /**
+     * Extracts classes out of an array of class strings.
+     *
+     * @param string[] $classes
+     *
+     * @return string[]
+     */
+    public function extract(array $classes): array
+    {
+        $found = [];
+
+        foreach ($classes as $class) {
+            $this->extractClasses($found, $class);
+        }
+
+        return $found;
+    }
+
+    /**
+     * Looks for related classes.
+     *
+     * @param string[] $found
+     * @param string $class
+     *
+     * @return string[]
+     */
+    private function extractClasses(array &$found, string $class): array
+    {
+        // If what we've found isnt a real class there is nothing to find.
+        if (\class_exists($class) === false &&
+            \interface_exists($class) === false) {
+            return [];
+        }
+
+        // We've already seen the class or it should be skipped based on configuration.
+        if (\in_array($class, $found, true) === true ||
+            $this->shouldSkip($class)
+        ) {
+            return [];
+        }
+
+        $found[] = $class;
+
+        $properties = $this->getProperties($class);
+
+        $discovered = [];
+
+        foreach ($properties as $property) {
+            $types = $this->propertyInfo->getTypes($class, $property);
+
+            // No types available.
+            if ($types === null) {
+                continue;
+            }
+
+            foreach ($types as $type) {
+                $foundClass = $this->findClass($type);
+
+                // Type didnt have a class.
+                if ($foundClass === null) {
+                    continue;
+                }
+
+                // Add a new found class and related classes to the stack.
+                $this->extractClasses($found, $foundClass);
+            }
+        }
+
+        return $discovered;
+    }
+
+    /**
+     * Finds a class for a type, if one exists.
+     *
+     * @param Type $type
+     *
+     * @return string|null
+     */
+    private function findClass(Type $type): ?string
+    {
+        // If we dont have an object builtin and it isnt a collection type we cant find
+        // any classes.
+        if ($type->getBuiltinType() !== Type::BUILTIN_TYPE_OBJECT &&
+            $type->isCollection() === false
+        ) {
+            return null;
+        }
+
+        // Use the annotated class..
+        $class = $type->getClassName();
+
+        // Unless we've got a collection type, then use the collection's type
+        if ($type->isCollection() === true &&
+            $type->getCollectionValueType() instanceof Type === true &&
+            $type->getCollectionValueType()->getBuiltinType() === Type::BUILTIN_TYPE_OBJECT
+        ) {
+            $class = $type->getCollectionValueType()->getClassName();
+        }
+
+        return $class;
+    }
+
+    /**
+     * Returns properties for the supplied class.
+     *
+     * @param string $class
+     *
+     * @return string[]
+     */
+    private function getProperties(string $class): array
+    {
+        $properties = $this->propertyInfo->getProperties($class) ?? [];
+
+        $properties = \array_filter($properties, static function (string $name): bool {
+            // Remove anything that starts with an underscore from being used in the Schema.
+            return $name[0] !== '_' &&
+                // Remove the statusCode property as a temporary measure to avoid
+                // the getStatusCode on responses from being added to every
+                // typed response.
+                $name !== 'statusCode';
+        });
+
+        return $properties;
+    }
+
+    /**
+     * Checks if the class should be skipped based on configuration.
+     *
+     * @param string $class
+     *
+     * @return bool
+     */
+    private function shouldSkip(string $class): bool
+    {
+        // Classes that we do not consider as objects, but scalars
+        static $scalarClasses = [
+            BaseDatetime::class,
+            DateTime::class,
+            DateTimeInterface::class,
+            UtcDateTime::class,
+        ];
+
+        $check = \array_merge($scalarClasses, $this->skipClasses);
+        // Builds an array of all classes to search for.
+        $implements = \array_merge(
+            \class_implements($class),
+            \class_parents($class)
+        );
+
+        // The class should be skipped if it matches one of the $check classes.
+        return \in_array($class, $check, true) === true ||
+            \count(\array_intersect($implements, $check)) > 0;
+    }
+}

--- a/src/Generator/ClassFinder.php
+++ b/src/Generator/ClassFinder.php
@@ -12,6 +12,16 @@ use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\Type;
 
+/**
+ * The class finder is used to traverse a graph of object classes and return
+ * a list of all classes that were found during that traversal.
+ *
+ * It is used to have a list of all objects that may be returned by the API
+ * so that Schema objects can be built for any possible returned values.
+ *
+ * The class can be configured to skip objects that should be considered as
+ * value objects (and that the serialiser will turn into scalar objects).
+ */
 final class ClassFinder
 {
     /**
@@ -75,7 +85,8 @@ final class ClassFinder
     }
 
     /**
-     * Looks for related classes.
+     * Traverse all properties of a class and look for type hints that indicate
+     * the property is an instance of another class.
      *
      * @param string[] $found
      * @param string $class
@@ -124,7 +135,7 @@ final class ClassFinder
     }
 
     /**
-     * Finds a class for a type, if one exists.
+     * Extracts a class out of a PropertyInfo type, if one can be found.
      *
      * @param \Symfony\Component\PropertyInfo\Type $type
      *

--- a/src/Generator/Interfaces/ClassFinderInterface.php
+++ b/src/Generator/Interfaces/ClassFinderInterface.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Generator\Interfaces;
+
+/**
+ * The class finder is used to traverse a graph of object classes and return
+ * a list of all classes that were found during that traversal.
+ *
+ * It is used to have a list of all objects that may be returned by the API
+ * so that Schema objects can be built for any possible returned values.
+ *
+ * The class can be configured to skip objects that should be considered as
+ * value objects (and that the serialiser will turn into scalar objects).
+ */
+interface ClassFinderInterface
+{
+    /**
+     * Returns all classes that are related to the input classes by traversing all
+     * properties on the initial classes looking for additional classes.
+     *
+     * @param string[] $classes
+     *
+     * @return string[]
+     */
+    public function extract(array $classes): array;
+}

--- a/src/Generator/buildReference.php
+++ b/src/Generator/buildReference.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore PSR1.Files.SideEffects.FoundWithSymbols Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen
 declare(strict_types=1);
 
 namespace LoyaltyCorp\ApiDocumenter\Generator;
@@ -8,7 +8,7 @@ namespace LoyaltyCorp\ApiDocumenter\Generator;
 // The whitespace in this file is relevant to work around an issue with PHP-CS-Fixer:
 // https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3868
 
-if (\function_exists(__NAMESPACE__ . '\buildReference') === false) {
+if (\function_exists(__NAMESPACE__ . '\buildReference') === false) { // phpcs:ignore
 
     // @codeCoverageIgnoreEnd
     false;

--- a/tests/Unit/Generator/ClassFinderTest.php
+++ b/tests/Unit/Generator/ClassFinderTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator;
+
+use DateTime;
+use LoyaltyCorp\ApiDocumenter\Generator\ClassFinder;
+use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
+use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\EmptyClass;
+use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\PrivateProperties;
+use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\PublicProperties;
+use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\SelfReference;
+use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\ValueObject;
+
+/**
+ * @covers \LoyaltyCorp\ApiDocumenter\Generator\ClassFinder
+ */
+final class ClassFinderTest extends TestCase
+{
+    /**
+     * Returns data to test class finder.
+     *
+     * @return mixed[]
+     */
+    public function getClassData(): iterable
+    {
+        yield 'non existant class' => [
+            'search' => ['PurpleElephants'],
+            'expected' => [],
+            'skip' => null,
+        ];
+
+        yield 'datetime' => [
+            'search' => [DateTime::class],
+            'expected' => [],
+            'skip' => null,
+        ];
+
+        yield 'empty class' => [
+            'search' => [EmptyClass::class],
+            'expected' => [EmptyClass::class],
+            'skip' => null,
+        ];
+
+        yield 'skipped class' => [
+            'search' => [EmptyClass::class],
+            'expected' => [],
+            'skip' => [EmptyClass::class],
+        ];
+
+        yield 'public properties' => [
+            'search' => [PublicProperties::class],
+            'expected' => [PublicProperties::class, EmptyClass::class, ValueObject::class],
+            'skip' => null,
+        ];
+
+        yield 'skipped related class' => [
+            'search' => [PublicProperties::class],
+            'expected' => [PublicProperties::class, ValueObject::class],
+            'skip' => [EmptyClass::class],
+        ];
+
+        yield 'private properties' => [
+            'search' => [PrivateProperties::class],
+            'expected' => [PrivateProperties::class, EmptyClass::class, PublicProperties::class, ValueObject::class],
+            'skip' => null,
+        ];
+
+        yield 'self reference' => [
+            'search' => [SelfReference::class],
+            'expected' => [SelfReference::class, EmptyClass::class],
+            'skip' => null,
+        ];
+    }
+
+    /**
+     * Tests the class finder works.
+     *
+     * @param string[] $search
+     * @param string[] $expected
+     * @param string[]|null $skip
+     *
+     * @return void
+     *
+     * @dataProvider getClassData
+     */
+    public function testClassFinder(array $search, array $expected, ?array $skip = null): void
+    {
+        $finder = new ClassFinder($skip ?? []);
+
+        $result = $finder->extract($search);
+
+        self::assertSame($expected, $result);
+    }
+}

--- a/tests/Unit/Generator/ClassFinderTest.php
+++ b/tests/Unit/Generator/ClassFinderTest.php
@@ -5,6 +5,9 @@ namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator;
 
 use DateTime;
 use LoyaltyCorp\ApiDocumenter\Generator\ClassFinder;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
 use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\EmptyClass;
 use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\PrivateProperties;
@@ -86,7 +89,25 @@ final class ClassFinderTest extends TestCase
      */
     public function testClassFinder(array $search, array $expected, ?array $skip = null): void
     {
-        $finder = new ClassFinder($skip ?? []);
+        $phpDocExtractor = new PhpDocExtractor();
+        $reflectionExtractor = new ReflectionExtractor(
+            null,
+            null,
+            null,
+            true,
+            ReflectionExtractor::ALLOW_PRIVATE |
+            ReflectionExtractor::ALLOW_PROTECTED |
+            ReflectionExtractor::ALLOW_PUBLIC
+        );
+        $propertyInfo = new PropertyInfoExtractor(
+            [$reflectionExtractor],
+            [$phpDocExtractor, $reflectionExtractor],
+            [$phpDocExtractor],
+            [],
+            []
+        );
+
+        $finder = new ClassFinder($propertyInfo, $skip ?? []);
 
         $result = $finder->extract($search);
 

--- a/tests/Unit/Generator/Fixtures/EmptyClass.php
+++ b/tests/Unit/Generator/Fixtures/EmptyClass.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures;
+
+/**
+ * @coversNothing
+ */
+final class EmptyClass
+{
+}

--- a/tests/Unit/Generator/Fixtures/PrivateProperties.php
+++ b/tests/Unit/Generator/Fixtures/PrivateProperties.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures;
+
+/**
+ * @coversNothing
+ */
+final class PrivateProperties
+{
+    /**
+     * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\EmptyClass
+     */
+    private $empty;
+
+    /**
+     * @var string
+     */
+    private $string;
+
+    /**
+     * Returns empty.
+     *
+     * @return \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\EmptyClass
+     */
+    public function getEmpty(): EmptyClass
+    {
+        return $this->empty;
+    }
+
+    /**
+     * While the serialiser will not serialise 'fakeout' as a property, we still
+     * support discovering the type here.
+     *
+     * @return \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\PublicProperties
+     */
+    public function getFakeout(): PublicProperties
+    {
+        return new PublicProperties();
+    }
+
+    /**
+     * Returns string.
+     *
+     * @return string
+     */
+    public function getString(): string
+    {
+        return $this->string;
+    }
+}

--- a/tests/Unit/Generator/Fixtures/PublicProperties.php
+++ b/tests/Unit/Generator/Fixtures/PublicProperties.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures;
+
+/**
+ * @coversNothing
+ */
+final class PublicProperties
+{
+    /**
+     * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\EmptyClass
+     */
+    public $empty;
+
+    /**
+     * We cant do much with a resource. This should be skipped.
+     *
+     * @var resource
+     */
+    public $resource;
+
+    /**
+     * @var string
+     */
+    public $string;
+
+    public $typeless; // phpcs:ignore
+
+    /**
+     * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\ValueObject[]
+     */
+    public $values = [];
+}

--- a/tests/Unit/Generator/Fixtures/SelfReference.php
+++ b/tests/Unit/Generator/Fixtures/SelfReference.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures;
+
+/**
+ * @coversNothing
+ */
+final class SelfReference
+{
+    /**
+     * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\EmptyClass
+     */
+    public $empty;
+
+    /**
+     * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\SelfReference
+     */
+    public $selfReference;
+}

--- a/tests/Unit/Generator/Fixtures/ValueObject.php
+++ b/tests/Unit/Generator/Fixtures/ValueObject.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures;
+
+/**
+ * @coversNothing
+ */
+final class ValueObject
+{
+    /**
+     * The value.
+     *
+     * @var string
+     */
+    public $string;
+}


### PR DESCRIPTION
This service is intended to take an array of classes and return an array of classes discovered while traversing all properties on the originally supplied classes.

It has provision for skipping specific classes that are intended on being value objects and will automatically skip DateTime and its derivatives.