### PR TITLE
PYMT-1336 property services

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -37,9 +37,6 @@ return PhpCsFixer\Config::create()
         // Seperates all class attributes by a blank line
         'class_attributes_separation' => true,
 
-        // When using annotations, a comment block is converted to a phpdoc
-        'comment_to_phpdoc' => true,
-
         // Enforces single space around the concat operator
         'concat_space' => [
             'spacing' => 'one'

--- a/src/Generator/ClassFinder.php
+++ b/src/Generator/ClassFinder.php
@@ -14,7 +14,7 @@ use Symfony\Component\PropertyInfo\Type;
 final class ClassFinder implements ClassFinderInterface
 {
     /**
-     * @var PropertyRetrieverInterface
+     * @var \LoyaltyCorp\ApiDocumenter\Generator\Interfaces\PropertyRetrieverInterface
      */
     private $propertyRetriever;
 
@@ -26,7 +26,7 @@ final class ClassFinder implements ClassFinderInterface
     /**
      * Constructor.
      *
-     * @param PropertyRetrieverInterface $propertyRetriever
+     * @param \LoyaltyCorp\ApiDocumenter\Generator\Interfaces\PropertyRetrieverInterface $propertyRetriever
      * @param string[] $skipClasses
      */
     public function __construct(

--- a/src/Generator/ClassFinder.php
+++ b/src/Generator/ClassFinder.php
@@ -8,15 +8,15 @@ use DateTimeInterface;
 use EoneoPay\Utils\DateTime;
 use EoneoPay\Utils\UtcDateTime;
 use LoyaltyCorp\ApiDocumenter\Generator\Interfaces\ClassFinderInterface;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use LoyaltyCorp\ApiDocumenter\Generator\Interfaces\PropertyRetrieverInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 final class ClassFinder implements ClassFinderInterface
 {
     /**
-     * @var \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface
+     * @var PropertyRetrieverInterface
      */
-    private $propertyInfo;
+    private $propertyRetriever;
 
     /**
      * @var string[]
@@ -26,14 +26,14 @@ final class ClassFinder implements ClassFinderInterface
     /**
      * Constructor.
      *
-     * @param \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface $propertyInfo
+     * @param PropertyRetrieverInterface $propertyRetriever
      * @param string[] $skipClasses
      */
     public function __construct(
-        PropertyInfoExtractorInterface $propertyInfo,
+        PropertyRetrieverInterface $propertyRetriever,
         array $skipClasses
     ) {
-        $this->propertyInfo = $propertyInfo;
+        $this->propertyRetriever = $propertyRetriever;
         $this->skipClasses = $skipClasses;
     }
 
@@ -77,10 +77,10 @@ final class ClassFinder implements ClassFinderInterface
 
         $found[] = $class;
 
-        $properties = $this->getProperties($class);
+        $properties = $this->propertyRetriever->getProperties($class);
 
         foreach ($properties as $property) {
-            $types = $this->propertyInfo->getTypes($class, $property);
+            $types = $this->propertyRetriever->getTypes($class, $property);
 
             // No types available.
             if ($types === null) {
@@ -130,29 +130,6 @@ final class ClassFinder implements ClassFinderInterface
         }
 
         return $class;
-    }
-
-    /**
-     * Returns properties for the supplied class.
-     *
-     * @param string $class
-     *
-     * @return string[]
-     */
-    private function getProperties(string $class): array
-    {
-        $properties = $this->propertyInfo->getProperties($class) ?? [];
-
-        $properties = \array_filter($properties, static function (string $name): bool {
-            // Remove anything that starts with an underscore from being used in the Schema.
-            return $name[0] !== '_' &&
-                // Remove the statusCode property as a temporary measure to avoid
-                // the getStatusCode on responses from being added to every
-                // typed response.
-                $name !== 'statusCode';
-        });
-
-        return $properties;
     }
 
     /**

--- a/src/Generator/Interfaces/OpenApiTypeResolverInterface.php
+++ b/src/Generator/Interfaces/OpenApiTypeResolverInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Generator\Interfaces;
+
+use Symfony\Component\PropertyInfo\Type;
+
+interface OpenApiTypeResolverInterface
+{
+    /**
+     * Returns the OpenAPI type to be used for the property type.
+     *
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     *
+     * @return mixed[]
+     */
+    public function resolvePropertyType(Type $type): array;
+}

--- a/src/Generator/Interfaces/PropertyRetrieverInterface.php
+++ b/src/Generator/Interfaces/PropertyRetrieverInterface.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Generator\Interfaces;
+
+use Symfony\Component\PropertyInfo\Type;
+
+interface PropertyRetrieverInterface
+{
+    /**
+     * Returns properties for the supplied class.
+     *
+     * @param string $class
+     *
+     * @return string[]
+     */
+    public function getProperties(string $class): array;
+
+    /**
+     * Returns the types for a property.
+     *
+     * @param string $class
+     * @param string $property
+     *
+     * @return Type[]
+     */
+    public function getTypes(string $class, string $property): ?array;
+}

--- a/src/Generator/Interfaces/PropertyRetrieverInterface.php
+++ b/src/Generator/Interfaces/PropertyRetrieverInterface.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\ApiDocumenter\Generator\Interfaces;
 
-use Symfony\Component\PropertyInfo\Type;
-
 interface PropertyRetrieverInterface
 {
     /**
@@ -22,7 +20,7 @@ interface PropertyRetrieverInterface
      * @param string $class
      * @param string $property
      *
-     * @return Type[]
+     * @return \Symfony\Component\PropertyInfo\Type[]
      */
     public function getTypes(string $class, string $property): ?array;
 }

--- a/src/Generator/Interfaces/PropertyTypeToSchemaConverterInterface.php
+++ b/src/Generator/Interfaces/PropertyTypeToSchemaConverterInterface.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Generator\Interfaces;
+
+use cebe\openapi\spec\Schema;
+use Symfony\Component\PropertyInfo\Type;
+
+interface PropertyTypeToSchemaConverterInterface
+{
+    /**
+     * Converts a PropertyInfo Type to a Schema.
+     *
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     *
+     * @return \cebe\openapi\spec\Schema|null
+     */
+    public function convert(Type $type): ?Schema;
+}

--- a/src/Generator/OpenApiTypeResolver.php
+++ b/src/Generator/OpenApiTypeResolver.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Generator;
+
+use DateTime as BaseDatetime;
+use DateTimeInterface;
+use EoneoPay\Utils\DateTime;
+use EoneoPay\Utils\UtcDateTime;
+use LoyaltyCorp\ApiDocumenter\Generator\Interfaces\OpenApiTypeResolverInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+final class OpenApiTypeResolver implements OpenApiTypeResolverInterface
+{
+    /**
+     * @noinspection MultipleReturnStatementsInspection
+     *
+     * {@inheritdoc}
+     */
+    public function resolvePropertyType(Type $type): array
+    {
+        static $dateTimeClasses = [
+            BaseDatetime::class,
+            DateTime::class,
+            DateTimeInterface::class,
+            UtcDateTime::class,
+        ];
+
+        if ($type->getBuiltinType() === Type::BUILTIN_TYPE_OBJECT &&
+            \in_array($type->getClassName(), $dateTimeClasses, true)
+        ) {
+            return ['string', 'date-time'];
+        }
+
+        if ($type->getBuiltinType() === Type::BUILTIN_TYPE_INT) {
+            return ['integer', 'int64'];
+        }
+
+        if ($type->getBuiltinType() === Type::BUILTIN_TYPE_FLOAT) {
+            return ['number', 'float'];
+        }
+
+        if ($type->getBuiltinType() === Type::BUILTIN_TYPE_STRING) {
+            return ['string', null];
+        }
+
+        if ($type->getBuiltinType() === Type::BUILTIN_TYPE_BOOL) {
+            return ['boolean', null];
+        }
+
+        return [null, null];
+    }
+}

--- a/src/Generator/PropertyRetriever.php
+++ b/src/Generator/PropertyRetriever.php
@@ -4,22 +4,21 @@ declare(strict_types=1);
 namespace LoyaltyCorp\ApiDocumenter\Generator;
 
 use LoyaltyCorp\ApiDocumenter\Generator\Interfaces\PropertyRetrieverInterface;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
-use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 
 final class PropertyRetriever implements PropertyRetrieverInterface
 {
     /**
-     * @var \Symfony\Component\PropertyInfo\PropertyListExtractorInterface
+     * @var \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface
      */
     private $propertyInfo;
 
     /**
      * Constructor.
      *
-     * @param \Symfony\Component\PropertyInfo\PropertyInfoExtractor $propertyInfo
+     * @param \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface $propertyInfo
      */
-    public function __construct(PropertyInfoExtractor $propertyInfo)
+    public function __construct(PropertyInfoExtractorInterface $propertyInfo)
     {
         $this->propertyInfo = $propertyInfo;
     }

--- a/src/Generator/PropertyRetriever.php
+++ b/src/Generator/PropertyRetriever.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Generator;
+
+use LoyaltyCorp\ApiDocumenter\Generator\Interfaces\PropertyRetrieverInterface;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\PropertyInfo\Type;
+
+final class PropertyRetriever implements PropertyRetrieverInterface
+{
+    /**
+     * @var \Symfony\Component\PropertyInfo\PropertyListExtractorInterface
+     */
+    private $propertyInfo;
+
+    /**
+     * Constructor.
+     *
+     * @param \Symfony\Component\PropertyInfo\PropertyInfoExtractor $propertyInfo
+     */
+    public function __construct(PropertyInfoExtractor $propertyInfo)
+    {
+        $this->propertyInfo = $propertyInfo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperties(string $class): array
+    {
+        $properties = $this->propertyInfo->getProperties($class) ?? [];
+
+        $properties = \array_filter($properties, static function (string $name): bool {
+            // Remove anything that starts with an underscore from being used in the Schema.
+            return $name[0] !== '_' &&
+                // Remove the statusCode property as a temporary measure to avoid
+                // the getStatusCode on responses from being added to every
+                // typed response.
+                $name !== 'statusCode';
+        });
+
+        return \array_values($properties);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypes(string $class, string $property): ?array
+    {
+        return $this->propertyInfo->getTypes($class, $property);
+    }
+}

--- a/src/Generator/PropertyTypeToSchemaConverter.php
+++ b/src/Generator/PropertyTypeToSchemaConverter.php
@@ -35,7 +35,7 @@ final class PropertyTypeToSchemaConverter implements PropertyTypeToSchemaConvert
         // If the type is a collection and has a value type, resolve
         // the collection type as an array.
         if ($type->isCollection() && $type->getCollectionValueType() instanceof Type === true) {
-            return $this->handleCollectionType($type);
+            return $this->handleCollectionType($type->getCollectionValueType());
         }
 
         // Try to resolve a primitive type
@@ -63,7 +63,7 @@ final class PropertyTypeToSchemaConverter implements PropertyTypeToSchemaConvert
      */
     private function handleCollectionType(Type $type): ?Schema
     {
-        $collectionSchema = $this->convert($type->getCollectionValueType());
+        $collectionSchema = $this->convert($type);
 
         // If we didnt get a collection value schema we cant infer the schema for
         // this property at all.

--- a/src/Generator/PropertyTypeToSchemaConverter.php
+++ b/src/Generator/PropertyTypeToSchemaConverter.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Generator;
+
+use cebe\openapi\spec\Schema;
+use LoyaltyCorp\ApiDocumenter\Generator\Interfaces\OpenApiTypeResolverInterface;
+use LoyaltyCorp\ApiDocumenter\Generator\Interfaces\PropertyTypeToSchemaConverterInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+final class PropertyTypeToSchemaConverter implements PropertyTypeToSchemaConverterInterface
+{
+    /**
+     * @var \LoyaltyCorp\ApiDocumenter\Generator\Interfaces\OpenApiTypeResolverInterface
+     */
+    private $typeResolver;
+
+    /**
+     * Constructor.
+     *
+     * @param \LoyaltyCorp\ApiDocumenter\Generator\Interfaces\OpenApiTypeResolverInterface $typeResolver
+     */
+    public function __construct(OpenApiTypeResolverInterface $typeResolver)
+    {
+        $this->typeResolver = $typeResolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \cebe\openapi\exceptions\TypeErrorException
+     */
+    public function convert(Type $type): ?Schema
+    {
+        // If the type is a collection and has a value type, resolve
+        // the collection type as an array.
+        if ($type->isCollection() && $type->getCollectionValueType() instanceof Type === true) {
+            return $this->handleCollectionType($type);
+        }
+
+        // Try to resolve a primitive type
+        [$primitiveType, $format] = $this->typeResolver->resolvePropertyType($type);
+
+        // If we got a primitive type, return its schema.
+        if (\is_string($primitiveType) === true &&
+            ($format === null || \is_string($format) === true)
+        ) {
+            return $this->handlePrimitiveType($primitiveType, $format);
+        }
+
+        return $this->handleObjectType($type);
+    }
+
+    /**
+     * Converts the collection value type and returns a Schema that indicates
+     * it should be an array of types.
+     *
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     *
+     * @return \cebe\openapi\spec\Schema|null
+     *
+     * @throws \cebe\openapi\exceptions\TypeErrorException
+     */
+    private function handleCollectionType(Type $type): ?Schema
+    {
+        $collectionSchema = $this->convert($type->getCollectionValueType());
+
+        // If we didnt get a collection value schema we cant infer the schema for
+        // this property at all.
+        if ($collectionSchema instanceof Schema === false) {
+            return null;
+        }
+
+        return new Schema([
+            'items' => $collectionSchema,
+            'type' => 'array',
+        ]);
+    }
+
+    /**
+     * Handles a type where no primitive type was resolved.
+     *
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     *
+     * @return \cebe\openapi\spec\Schema|null
+     *
+     * @throws \cebe\openapi\exceptions\TypeErrorException
+     */
+    private function handleObjectType(Type $type): ?Schema
+    {
+        $className = $type->getClassName();
+
+        // If there is no class name or the class or interface doesnt exist
+        // we cannot resolve a schema.
+        if ($className === null ||
+            (
+                \class_exists($className) === false &&
+                \interface_exists($className) === false
+            )
+        ) {
+            return null;
+        }
+
+        $ref = \LoyaltyCorp\ApiDocumenter\Generator\buildReference($className);
+
+        return new Schema([
+            '$ref' => $ref,
+        ]);
+    }
+
+    /**
+     * Handles a primitive type.
+     *
+     * @param string $primitiveType
+     * @param string|null $format
+     *
+     * @return \cebe\openapi\spec\Schema
+     *
+     * @throws \cebe\openapi\exceptions\TypeErrorException
+     */
+    private function handlePrimitiveType(string $primitiveType, ?string $format): Schema
+    {
+        $schema = new Schema([
+            'type' => $primitiveType,
+        ]);
+
+        if ($format !== null) {
+            $schema->format = $format;
+        }
+
+        return $schema;
+    }
+}

--- a/src/Generator/buildReference.php
+++ b/src/Generator/buildReference.php
@@ -1,18 +1,12 @@
-<?php // phpcs:ignore PSR1.Files.SideEffects.FoundWithSymbols Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen
+<?php // phpcs:ignore PSR1.Files.SideEffects.FoundWithSymbols
 declare(strict_types=1);
 
 namespace LoyaltyCorp\ApiDocumenter\Generator;
 
 // Only define the buildReference function if it doesnt already exist.
 // @codeCoverageIgnoreStart
-// The whitespace in this file is relevant to work around an issue with PHP-CS-Fixer:
-// https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3868
-
 if (\function_exists(__NAMESPACE__ . '\buildReference') === false) { // phpcs:ignore
-
-    // @codeCoverageIgnoreEnd
-    false;
-
+// @codeCoverageIgnoreEnd
     /**
      * Builds a reference for use inside the OpenAPI specification file.
      *

--- a/tests/Unit/Generator/ClassFinderTest.php
+++ b/tests/Unit/Generator/ClassFinderTest.php
@@ -18,6 +18,8 @@ use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\ValueObject;
 
 /**
  * @covers \LoyaltyCorp\ApiDocumenter\Generator\ClassFinder
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Required to test
  */
 final class ClassFinderTest extends TestCase
 {

--- a/tests/Unit/Generator/ClassFinderTest.php
+++ b/tests/Unit/Generator/ClassFinderTest.php
@@ -5,6 +5,7 @@ namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator;
 
 use DateTime;
 use LoyaltyCorp\ApiDocumenter\Generator\ClassFinder;
+use LoyaltyCorp\ApiDocumenter\Generator\PropertyRetriever;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
@@ -107,7 +108,9 @@ final class ClassFinderTest extends TestCase
             []
         );
 
-        $finder = new ClassFinder($propertyInfo, $skip ?? []);
+        $propertyRetriever = new PropertyRetriever($propertyInfo);
+
+        $finder = new ClassFinder($propertyRetriever, $skip ?? []);
 
         $result = $finder->extract($search);
 

--- a/tests/Unit/Generator/Fixtures/PublicProperties.php
+++ b/tests/Unit/Generator/Fixtures/PublicProperties.php
@@ -5,6 +5,8 @@ namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures;
 
 /**
  * @coversNothing
+ *
+ * @SuppressWarnings(PHPMD) Class is hanky, and triggers phpmd errors in order to test functionality
  */
 final class PublicProperties
 {
@@ -13,7 +15,7 @@ final class PublicProperties
      *
      * @var null
      */
-    public $_skipThis;
+    public $_skipThis; // phpcs:ignore
 
     /**
      * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\EmptyClass
@@ -30,12 +32,12 @@ final class PublicProperties
     /**
      * @var string
      */
-    public $string; // phpcs:ignore
+    public $string;
 
-    public $typeless;
+    public $typeless; // phpcs:ignore
 
-        /**
+    /**
      * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\ValueObject[]
      */
-    public $values = []; // phpcs:ignore
+    public $values = [];
 }

--- a/tests/Unit/Generator/Fixtures/PublicProperties.php
+++ b/tests/Unit/Generator/Fixtures/PublicProperties.php
@@ -9,6 +9,13 @@ namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures;
 final class PublicProperties
 {
     /**
+     * A property that should not appear anywhere because it is prefixed with an underscore.
+     *
+     * @var null
+     */
+    public $_skipThis;
+
+    /**
      * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\EmptyClass
      */
     public $empty;
@@ -23,12 +30,12 @@ final class PublicProperties
     /**
      * @var string
      */
-    public $string;
+    public $string; // phpcs:ignore
 
-    public $typeless; // phpcs:ignore
+    public $typeless;
 
-    /**
+        /**
      * @var \Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\ValueObject[]
      */
-    public $values = [];
+    public $values = []; // phpcs:ignore
 }

--- a/tests/Unit/Generator/OpenApiTypeResolverTest.php
+++ b/tests/Unit/Generator/OpenApiTypeResolverTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator;
+
+use DateTime as BaseDateTime;
+use EoneoPay\Utils\DateTime;
+use LoyaltyCorp\ApiDocumenter\Generator\OpenApiTypeResolver;
+use Symfony\Component\PropertyInfo\Type;
+use Tests\LoyaltyCorp\ApiDocumenter\Fixtures\Request;
+use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\ApiDocumenter\Generator\OpenApiTypeResolver
+ */
+final class OpenApiTypeResolverTest extends TestCase
+{
+    /**
+     * Returns test data for the type resolver.
+     *
+     * @return mixed[]
+     */
+    public function getTestData(): iterable
+    {
+        yield 'a class' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                true,
+                Request::class
+            ),
+            'expected' => [null, null],
+        ];
+
+        yield 'a resource' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_RESOURCE
+            ),
+            'expected' => [null, null],
+        ];
+
+        yield 'an array' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_ARRAY
+            ),
+            'expected' => [null, null],
+        ];
+
+        yield 'null' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_NULL
+            ),
+            'expected' => [null, null],
+        ];
+
+        yield 'a callable' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_CALLABLE
+            ),
+            'expected' => [null, null],
+        ];
+
+        yield 'a datetime' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                BaseDateTime::class
+            ),
+            'expected' => ['string', 'date-time'],
+        ];
+
+        yield 'a utils datetime' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                DateTime::class
+            ),
+            'expected' => ['string', 'date-time'],
+        ];
+
+        yield 'an integer' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_INT
+            ),
+            'expected' => ['integer', 'int64'],
+        ];
+
+        yield 'a float' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_FLOAT
+            ),
+            'expected' => ['number', 'float'],
+        ];
+
+        yield 'a string' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_STRING
+            ),
+            'expected' => ['string', null],
+        ];
+
+        yield 'a bool' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_BOOL
+            ),
+            'expected' => ['boolean', null],
+        ];
+    }
+
+    /**
+     * Tests that resolved property types match the OpenApi specification
+     * for those types.
+     *
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     * @param mixed[] $expected
+     *
+     * @return void
+     *
+     * @dataProvider getTestData
+     */
+    public function testResolvedPropertyType(Type $type, array $expected): void
+    {
+        $resolver = new OpenApiTypeResolver();
+
+        $actual = $resolver->resolvePropertyType($type);
+
+        self::assertSame($expected, $actual);
+    }
+}

--- a/tests/Unit/Generator/PropertyRetrieverTest.php
+++ b/tests/Unit/Generator/PropertyRetrieverTest.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator;
+
+use LoyaltyCorp\ApiDocumenter\Generator\PropertyRetriever;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\PropertyInfo\Type;
+use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
+use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\PublicProperties;
+
+/**
+ * @covers \LoyaltyCorp\ApiDocumenter\Generator\PropertyRetriever
+ */
+final class PropertyRetrieverTest extends TestCase
+{
+    /**
+     * Tests that the property retriever retrieves properties.
+     *
+     * @return void
+     */
+    public function testGetProperties(): void
+    {
+        $retriever = $this->getRetriever();
+
+        $expected = [
+            'empty',
+            'resource',
+            'string',
+            'typeless',
+            'values'
+        ];
+
+        $actual = $retriever->getProperties(PublicProperties::class);
+
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * Tests that the property retriever retrieves properties.
+     *
+     * @return void
+     */
+    public function testGetTypes(): void
+    {
+        $retriever = $this->getRetriever();
+
+        $expected = [
+            new Type(
+                Type::BUILTIN_TYPE_STRING,
+                false,
+                null,
+                false,
+                null,
+                null
+            )
+        ];
+
+        $actual = $retriever->getTypes(PublicProperties::class, 'string');
+
+        static::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Returns the retriever under test.
+     *
+     * @return PropertyRetriever
+     */
+    private function getRetriever(): PropertyRetriever
+    {
+        $phpDocExtractor = new PhpDocExtractor();
+        $reflectionExtractor = new ReflectionExtractor(
+            null,
+            null,
+            null,
+            true,
+            ReflectionExtractor::ALLOW_PRIVATE |
+            ReflectionExtractor::ALLOW_PROTECTED |
+            ReflectionExtractor::ALLOW_PUBLIC
+        );
+        $propertyInfo = new PropertyInfoExtractor(
+            [$reflectionExtractor],
+            [$phpDocExtractor, $reflectionExtractor],
+            [$phpDocExtractor],
+            [],
+            []
+        );
+
+        return new PropertyRetriever($propertyInfo);
+    }
+}

--- a/tests/Unit/Generator/PropertyRetrieverTest.php
+++ b/tests/Unit/Generator/PropertyRetrieverTest.php
@@ -30,12 +30,12 @@ final class PropertyRetrieverTest extends TestCase
             'resource',
             'string',
             'typeless',
-            'values'
+            'values',
         ];
 
         $actual = $retriever->getProperties(PublicProperties::class);
 
-        static::assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -55,18 +55,18 @@ final class PropertyRetrieverTest extends TestCase
                 false,
                 null,
                 null
-            )
+            ),
         ];
 
         $actual = $retriever->getTypes(PublicProperties::class, 'string');
 
-        static::assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
      * Returns the retriever under test.
      *
-     * @return PropertyRetriever
+     * @return \LoyaltyCorp\ApiDocumenter\Generator\PropertyRetriever
      */
     private function getRetriever(): PropertyRetriever
     {

--- a/tests/Unit/Generator/PropertyTypeToSchemaConverterTest.php
+++ b/tests/Unit/Generator/PropertyTypeToSchemaConverterTest.php
@@ -1,0 +1,152 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator;
+
+use cebe\openapi\spec\Schema;
+use LoyaltyCorp\ApiDocumenter\Generator\OpenApiTypeResolver;
+use LoyaltyCorp\ApiDocumenter\Generator\PropertyTypeToSchemaConverter;
+use Symfony\Component\PropertyInfo\Type;
+use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
+use Tests\LoyaltyCorp\ApiDocumenter\Unit\Generator\Fixtures\PublicProperties;
+
+/**
+ * @covers \LoyaltyCorp\ApiDocumenter\Generator\PropertyTypeToSchemaConverter
+ */
+final class PropertyTypeToSchemaConverterTest extends TestCase
+{
+    /**
+     * Returns test data.
+     *
+     * @return mixed
+     *
+     * @throws \cebe\openapi\exceptions\TypeErrorException
+     */
+    public function getConversionData(): iterable
+    {
+        yield 'object type' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                PublicProperties::class
+            ),
+            'schema' => new Schema([
+                '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterUnitGeneratorFixturesPublicProperties' // phpcs:ignore
+            ])
+        ];
+
+        yield 'object type with no class' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_OBJECT
+            ),
+            'schema' => null
+        ];
+
+        yield 'non existant object type' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                'doesntexist'
+            ),
+            'schema' => null
+        ];
+
+        yield 'scalar string' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_STRING
+            ),
+            'schema' => new Schema([
+                'type' => 'string'
+            ])
+        ];
+
+        yield 'scalar integer' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_INT
+            ),
+            'schema' => new Schema([
+                'type' => 'integer',
+                'format' => 'int64'
+            ])
+        ];
+
+        yield 'collection integer' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_ARRAY,
+                false,
+                null,
+                true,
+                null,
+                new Type(
+                    Type::BUILTIN_TYPE_INT
+                )
+            ),
+            'schema' => new Schema([
+                'items' => new Schema([
+                    'type' => 'integer',
+                    'format' => 'int64'
+                ]),
+                'type' => 'array'
+            ])
+        ];
+
+        yield 'collection object' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_ARRAY,
+                false,
+                null,
+                true,
+                null,
+                new Type(
+                    Type::BUILTIN_TYPE_OBJECT,
+                    false,
+                    PublicProperties::class
+                )
+            ),
+            'schema' => new Schema([
+                'items' => new Schema([
+                    '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterUnitGeneratorFixturesPublicProperties' // phpcs:ignore
+                ]),
+                'type' => 'array'
+            ])
+        ];
+
+        yield 'collection unknown object' => [
+            'type' => new Type(
+                Type::BUILTIN_TYPE_ARRAY,
+                false,
+                null,
+                true,
+                null,
+                new Type(
+                    Type::BUILTIN_TYPE_OBJECT,
+                    false,
+                    'doesntexist'
+                )
+            ),
+            'schema' => null
+        ];
+    }
+
+    /**
+     * Tests the converter.
+     *
+     * @param Type $type
+     * @param Schema $expected
+     *
+     * @return void
+     *
+     * @throws \cebe\openapi\exceptions\TypeErrorException
+     *
+     * @dataProvider getConversionData
+     */
+    public function testConversion(Type $type, ?Schema $expected): void
+    {
+        $typeResolver = new OpenApiTypeResolver();
+        $converter = new PropertyTypeToSchemaConverter($typeResolver);
+
+        $actual = $converter->convert($type);
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/Unit/Generator/PropertyTypeToSchemaConverterTest.php
+++ b/tests/Unit/Generator/PropertyTypeToSchemaConverterTest.php
@@ -18,9 +18,11 @@ final class PropertyTypeToSchemaConverterTest extends TestCase
     /**
      * Returns test data.
      *
-     * @return mixed
+     * @return mixed[]
      *
      * @throws \cebe\openapi\exceptions\TypeErrorException
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function getConversionData(): iterable
     {
@@ -31,15 +33,15 @@ final class PropertyTypeToSchemaConverterTest extends TestCase
                 PublicProperties::class
             ),
             'schema' => new Schema([
-                '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterUnitGeneratorFixturesPublicProperties' // phpcs:ignore
-            ])
+                '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterUnitGeneratorFixturesPublicProperties', // phpcs:ignore
+            ]),
         ];
 
         yield 'object type with no class' => [
             'type' => new Type(
                 Type::BUILTIN_TYPE_OBJECT
             ),
-            'schema' => null
+            'schema' => null,
         ];
 
         yield 'non existant object type' => [
@@ -48,7 +50,7 @@ final class PropertyTypeToSchemaConverterTest extends TestCase
                 false,
                 'doesntexist'
             ),
-            'schema' => null
+            'schema' => null,
         ];
 
         yield 'scalar string' => [
@@ -56,8 +58,8 @@ final class PropertyTypeToSchemaConverterTest extends TestCase
                 Type::BUILTIN_TYPE_STRING
             ),
             'schema' => new Schema([
-                'type' => 'string'
-            ])
+                'type' => 'string',
+            ]),
         ];
 
         yield 'scalar integer' => [
@@ -66,8 +68,8 @@ final class PropertyTypeToSchemaConverterTest extends TestCase
             ),
             'schema' => new Schema([
                 'type' => 'integer',
-                'format' => 'int64'
-            ])
+                'format' => 'int64',
+            ]),
         ];
 
         yield 'collection integer' => [
@@ -84,10 +86,10 @@ final class PropertyTypeToSchemaConverterTest extends TestCase
             'schema' => new Schema([
                 'items' => new Schema([
                     'type' => 'integer',
-                    'format' => 'int64'
+                    'format' => 'int64',
                 ]),
-                'type' => 'array'
-            ])
+                'type' => 'array',
+            ]),
         ];
 
         yield 'collection object' => [
@@ -105,10 +107,10 @@ final class PropertyTypeToSchemaConverterTest extends TestCase
             ),
             'schema' => new Schema([
                 'items' => new Schema([
-                    '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterUnitGeneratorFixturesPublicProperties' // phpcs:ignore
+                    '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterUnitGeneratorFixturesPublicProperties', // phpcs:ignore
                 ]),
-                'type' => 'array'
-            ])
+                'type' => 'array',
+            ]),
         ];
 
         yield 'collection unknown object' => [
@@ -124,15 +126,15 @@ final class PropertyTypeToSchemaConverterTest extends TestCase
                     'doesntexist'
                 )
             ),
-            'schema' => null
+            'schema' => null,
         ];
     }
 
     /**
      * Tests the converter.
      *
-     * @param Type $type
-     * @param Schema $expected
+     * @param \Symfony\Component\PropertyInfo\Type $type
+     * @param \cebe\openapi\spec\Schema $expected
      *
      * @return void
      *


### PR DESCRIPTION
This PR contains extractions from the POC that are mostly "helper" services for the generation process.

- Extracted a PropertyRetriever from ClassFinder so it can be used in other services that will be required to find properties on a class
- A Type Resolver that converts a symfony property info Type into an OpenApi type
- A converter that turns a Type into an openapi Schema