### PR TITLE
Be aware of doctrine collections

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1734,16 +1734,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.6",
+            "version": "v1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3"
+                "reference": "ffcde9615dc5bb4825b9f6aed07716f1f57faae0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
-                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffcde9615dc5bb4825b9f6aed07716f1f57faae0",
+                "reference": "ffcde9615dc5bb4825b9f6aed07716f1f57faae0",
                 "shasum": ""
             },
             "require": {
@@ -1788,7 +1788,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-08-20T14:44:19+00:00"
+            "time": "2019-09-17T11:12:18+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/tests/Stubs/Vendor/Symfony/PropertyInfo/PropertyInfoExtractorStub.php
+++ b/tests/Stubs/Vendor/Symfony/PropertyInfo/PropertyInfoExtractorStub.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Stubs\Vendor\Symfony\PropertyInfo;
+
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+
+final class PropertyInfoExtractorStub implements PropertyInfoExtractorInterface
+{
+    /**
+     * @var \Symfony\Component\PropertyInfo\Type[]
+     */
+    private $types;
+
+    /**
+     * Constructor.
+     *
+     * @param \Symfony\Component\PropertyInfo\Type[] $types
+     */
+    public function __construct(array $types)
+    {
+        $this->types = $types;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLongDescription($class, $property, array $context = []): string
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperties($class, array $context = []): ?array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getShortDescription($class, $property, array $context = []): string
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypes($class, $property, array $context = []): ?array
+    {
+        return $this->types;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isReadable($class, $property, array $context = []): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isWritable($class, $property, array $context = []): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/ClassUtils/ClassFinderTest.php
+++ b/tests/Unit/ClassUtils/ClassFinderTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor as BasePropertyInfoExtractor;
 use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
+use Tests\LoyaltyCorp\ApiDocumenter\Unit\SchemaBuilders\Fixtures\DoctrineObject;
 use Tests\LoyaltyCorp\ApiDocumenter\Unit\SchemaBuilders\Fixtures\EmptyClass;
 use Tests\LoyaltyCorp\ApiDocumenter\Unit\SchemaBuilders\Fixtures\PrivateProperties;
 use Tests\LoyaltyCorp\ApiDocumenter\Unit\SchemaBuilders\Fixtures\PublicProperties;
@@ -52,6 +53,12 @@ final class ClassFinderTest extends TestCase
             'search' => [EmptyClass::class],
             'expected' => [],
             'skip' => [EmptyClass::class],
+        ];
+
+        yield 'class with doctrine collection' => [
+            'search' => [DoctrineObject::class],
+            'expected' => [DoctrineObject::class, EmptyClass::class],
+            'skip' => [],
         ];
 
         yield 'public properties' => [

--- a/tests/Unit/ClassUtils/PropertyInfoExtractorTest.php
+++ b/tests/Unit/ClassUtils/PropertyInfoExtractorTest.php
@@ -24,6 +24,48 @@ final class PropertyInfoExtractorTest extends TestCase
      *
      * @return void
      */
+    public function testDualTypesNotCollection(): void
+    {
+        $propertyStub = new PropertyInfoExtractorStub([
+            new Type(
+                Type::BUILTIN_TYPE_STRING
+            ),
+            new Type(
+                Type::BUILTIN_TYPE_ARRAY,
+                false,
+                null,
+                true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_STRING)
+            ),
+        ]);
+
+        $retriever = $this->getRetriever($propertyStub);
+
+        $expected = [
+            new Type(
+                Type::BUILTIN_TYPE_STRING
+            ),
+            new Type(
+                Type::BUILTIN_TYPE_ARRAY,
+                false,
+                null,
+                true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_STRING)
+            ),
+        ];
+
+        $actual = $retriever->getTypes(PublicProperties::class, 'string');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the property retriever retrieves properties.
+     *
+     * @return void
+     */
     public function testGetProperties(): void
     {
         $retriever = $this->getRetriever();
@@ -88,48 +130,6 @@ final class PropertyInfoExtractorTest extends TestCase
      *
      * @return void
      */
-    public function testDualTypesNotCollection(): void
-    {
-        $propertyStub = new PropertyInfoExtractorStub([
-            new Type(
-                Type::BUILTIN_TYPE_STRING
-            ),
-            new Type(
-                Type::BUILTIN_TYPE_ARRAY,
-                false,
-                null,
-                true,
-                new Type(Type::BUILTIN_TYPE_INT),
-                new Type(Type::BUILTIN_TYPE_STRING)
-            ),
-        ]);
-
-        $retriever = $this->getRetriever($propertyStub);
-
-        $expected = [
-            new Type(
-                Type::BUILTIN_TYPE_STRING
-            ),
-            new Type(
-                Type::BUILTIN_TYPE_ARRAY,
-                false,
-                null,
-                true,
-                new Type(Type::BUILTIN_TYPE_INT),
-                new Type(Type::BUILTIN_TYPE_STRING)
-            ),
-        ];
-
-        $actual = $retriever->getTypes(PublicProperties::class, 'string');
-
-        self::assertEquals($expected, $actual);
-    }
-
-    /**
-     * Tests that the property retriever retrieves properties.
-     *
-     * @return void
-     */
     public function testGetTypes(): void
     {
         $retriever = $this->getRetriever();
@@ -171,7 +171,7 @@ final class PropertyInfoExtractorTest extends TestCase
     /**
      * Returns the retriever under test.
      *
-     * @param null|PropertyInfoExtractorInterface $propertyInfo
+     * @param \Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface|null $propertyInfo
      *
      * @return \LoyaltyCorp\ApiDocumenter\ClassUtils\PropertyInfoExtractor
      */

--- a/tests/Unit/ClassUtils/PropertyInfoExtractorTest.php
+++ b/tests/Unit/ClassUtils/PropertyInfoExtractorTest.php
@@ -3,11 +3,14 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\ClassUtils;
 
+use Doctrine\Common\Collections\Collection;
 use LoyaltyCorp\ApiDocumenter\ClassUtils\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor as BasePropertyInfoExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
+use Tests\LoyaltyCorp\ApiDocumenter\Stubs\Vendor\Symfony\PropertyInfo\PropertyInfoExtractorStub;
 use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
 use Tests\LoyaltyCorp\ApiDocumenter\Unit\SchemaBuilders\Fixtures\PublicProperties;
 
@@ -37,6 +40,89 @@ final class PropertyInfoExtractorTest extends TestCase
         $actual = $retriever->getProperties(PublicProperties::class);
 
         self::assertSame($expected, $actual);
+    }
+
+    /**
+     * Tests that the property retriever retrieves properties.
+     *
+     * @return void
+     */
+    public function testGetTypeCollectionCollapsing(): void
+    {
+        $propertyStub = new PropertyInfoExtractorStub([
+            new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                Collection::class
+            ),
+            new Type(
+                Type::BUILTIN_TYPE_ARRAY,
+                false,
+                null,
+                true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_STRING)
+            ),
+        ]);
+
+        $retriever = $this->getRetriever($propertyStub);
+
+        $expected = [
+            new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                Collection::class,
+                true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_STRING)
+            ),
+        ];
+
+        $actual = $retriever->getTypes(PublicProperties::class, 'string');
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the property retriever retrieves properties.
+     *
+     * @return void
+     */
+    public function testDualTypesNotCollection(): void
+    {
+        $propertyStub = new PropertyInfoExtractorStub([
+            new Type(
+                Type::BUILTIN_TYPE_STRING
+            ),
+            new Type(
+                Type::BUILTIN_TYPE_ARRAY,
+                false,
+                null,
+                true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_STRING)
+            ),
+        ]);
+
+        $retriever = $this->getRetriever($propertyStub);
+
+        $expected = [
+            new Type(
+                Type::BUILTIN_TYPE_STRING
+            ),
+            new Type(
+                Type::BUILTIN_TYPE_ARRAY,
+                false,
+                null,
+                true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_STRING)
+            ),
+        ];
+
+        $actual = $retriever->getTypes(PublicProperties::class, 'string');
+
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -85,27 +171,31 @@ final class PropertyInfoExtractorTest extends TestCase
     /**
      * Returns the retriever under test.
      *
+     * @param null|PropertyInfoExtractorInterface $propertyInfo
+     *
      * @return \LoyaltyCorp\ApiDocumenter\ClassUtils\PropertyInfoExtractor
      */
-    private function getRetriever(): PropertyInfoExtractor
+    private function getRetriever(?PropertyInfoExtractorInterface $propertyInfo = null): PropertyInfoExtractor
     {
-        $phpDocExtractor = new PhpDocExtractor();
-        $reflectionExtractor = new ReflectionExtractor(
-            null,
-            null,
-            null,
-            true,
-            ReflectionExtractor::ALLOW_PRIVATE |
-            ReflectionExtractor::ALLOW_PROTECTED |
-            ReflectionExtractor::ALLOW_PUBLIC
-        );
-        $propertyInfo = new BasePropertyInfoExtractor(
-            [$reflectionExtractor],
-            [$phpDocExtractor, $reflectionExtractor],
-            [$phpDocExtractor],
-            [],
-            []
-        );
+        if ($propertyInfo === null) {
+            $phpDocExtractor = new PhpDocExtractor();
+            $reflectionExtractor = new ReflectionExtractor(
+                null,
+                null,
+                null,
+                true,
+                ReflectionExtractor::ALLOW_PRIVATE |
+                ReflectionExtractor::ALLOW_PROTECTED |
+                ReflectionExtractor::ALLOW_PUBLIC
+            );
+            $propertyInfo = new BasePropertyInfoExtractor(
+                [$reflectionExtractor],
+                [$phpDocExtractor, $reflectionExtractor],
+                [$phpDocExtractor],
+                [],
+                []
+            );
+        }
 
         return new PropertyInfoExtractor($propertyInfo);
     }

--- a/tests/Unit/SchemaBuilders/Fixtures/DoctrineObject.php
+++ b/tests/Unit/SchemaBuilders/Fixtures/DoctrineObject.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\SchemaBuilders\Fixtures;
+
+/**
+ * @coversNothing
+ */
+final class DoctrineObject
+{
+    /**
+     * Summary.
+     *
+     * phpcs:disable
+     *
+     * @var \Doctrine\Common\Collections\Collection|\Tests\LoyaltyCorp\ApiDocumenter\Unit\SchemaBuilders\Fixtures\EmptyClass[]
+     *
+     * phpcs:enable
+     */
+    public $collection;
+}


### PR DESCRIPTION
PropertyInfo is not aware of Doctrine collections by default. The doctrine-bridge provided by symfony would work here, but it adds a lot of baggage (and requires an EntityManager reference to work) which we dont need.

I've implemented an override of getTypes() that smooshes types together when they match the condition `type1 === doctrine collection && type2 === array collection` into a single type.