### PR TITLE
PYMT-1335 apidoc examples

### DIFF
--- a/src/Documentation/Generator.php
+++ b/src/Documentation/Generator.php
@@ -11,6 +11,7 @@ use LoyaltyCorp\ApiDocumenter\Documentation\Interfaces\RoutesToSchemasConverterI
 use LoyaltyCorp\ApiDocumenter\Routing\Interfaces\RouteEnhancerInterface;
 use LoyaltyCorp\ApiDocumenter\Routing\Interfaces\RouteExtractorInterface;
 use LoyaltyCorp\ApiDocumenter\Routing\Interfaces\RouteToPathItemConverterInterface;
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExamples;
 
 final class Generator implements GeneratorInterface
 {
@@ -66,7 +67,7 @@ final class Generator implements GeneratorInterface
      *
      * @throws \cebe\openapi\exceptions\TypeErrorException
      */
-    public function generate(string $name, string $version): string
+    public function generate(string $name, string $version, ?RouteExamples $examples = null): string
     {
         $routes = $this->routeExtractor->getRoutes();
         foreach ($routes as $route) {
@@ -74,7 +75,7 @@ final class Generator implements GeneratorInterface
         }
 
         $schemas = $this->schemaConverter->convert($routes);
-        $paths = $this->pathItemConverter->convert($routes);
+        $paths = $this->pathItemConverter->convert($routes, $examples ?? new RouteExamples([]));
 
         $root = new OpenApi([
             'openapi' => static::TARGET_OPENAPI_VERSION,

--- a/src/Documentation/Interfaces/GeneratorInterface.php
+++ b/src/Documentation/Interfaces/GeneratorInterface.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\ApiDocumenter\Documentation\Interfaces;
 
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExamples;
+
 interface GeneratorInterface
 {
     /**
@@ -10,8 +12,9 @@ interface GeneratorInterface
      *
      * @param string $name
      * @param string $version
+     * @param \LoyaltyCorp\ApiDocumenter\Routing\RouteExamples|null $examples
      *
      * @return string
      */
-    public function generate(string $name, string $version): string;
+    public function generate(string $name, string $version, ?RouteExamples $examples = null): string;
 }

--- a/src/Routing/Interfaces/RouteToPathItemConverterInterface.php
+++ b/src/Routing/Interfaces/RouteToPathItemConverterInterface.php
@@ -3,14 +3,17 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\ApiDocumenter\Routing\Interfaces;
 
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExamples;
+
 interface RouteToPathItemConverterInterface
 {
     /**
      * Converts an array of Route objects into the OpenApi PathItem objects.
      *
      * @param \LoyaltyCorp\ApiDocumenter\Routing\Route[] $routes
+     * @param \LoyaltyCorp\ApiDocumenter\Routing\RouteExamples $examples
      *
      * @return \cebe\openapi\spec\PathItem[]
      */
-    public function convert(array $routes): array;
+    public function convert(array $routes, RouteExamples $examples): array;
 }

--- a/src/Routing/RouteExample.php
+++ b/src/Routing/RouteExample.php
@@ -1,0 +1,155 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Routing;
+
+final class RouteExample
+{
+    /**
+     * A longer description of the example.
+     *
+     * @var string|null
+     */
+    private $description;
+
+    /**
+     * The method of the request.
+     *
+     * @var string
+     */
+    private $method;
+
+    /**
+     * The Path the request was made to.
+     *
+     * @var string
+     */
+    private $path;
+
+    /**
+     * Stores the JSON representation of the example.
+     *
+     * @var string|null
+     */
+    private $requestData;
+
+    /**
+     * JSON string response.
+     *
+     * @var string|null
+     */
+    private $responseData;
+
+    /**
+     * The status code of the response.
+     *
+     * @var int
+     */
+    private $responseStatusCode;
+
+    /**
+     * The one line summary of the example.
+     *
+     * @var string
+     */
+    private $summary;
+
+    /**
+     * Constructor.
+     *
+     * @param string|null $description
+     * @param string $method
+     * @param string $path
+     * @param string|null $requestData
+     * @param string|null $responseData
+     * @param int $responseStatusCode
+     * @param string $summary
+     */
+    public function __construct(
+        ?string $description,
+        string $method,
+        string $path,
+        ?string $requestData,
+        ?string $responseData,
+        int $responseStatusCode,
+        string $summary
+    ) {
+        $this->description = $description;
+        $this->method = $method;
+        $this->path = $path;
+        $this->requestData = $requestData;
+        $this->responseData = $responseData;
+        $this->responseStatusCode = $responseStatusCode;
+        $this->summary = $summary;
+    }
+
+    /**
+     * Returns description.
+     *
+     * @return string|null
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Returns method.
+     *
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * Returns path.
+     *
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Returns request data.
+     *
+     * @return string|null
+     */
+    public function getRequestData(): ?string
+    {
+        return $this->requestData;
+    }
+
+    /**
+     * Returns response data.
+     *
+     * @return string|null
+     */
+    public function getResponseData(): ?string
+    {
+        return $this->responseData;
+    }
+
+    /**
+     * Returns status code.
+     *
+     * @return int
+     */
+    public function getResponseStatusCode(): int
+    {
+        return $this->responseStatusCode;
+    }
+
+    /**
+     * Returns summary.
+     *
+     * @return string
+     */
+    public function getSummary(): string
+    {
+        return $this->summary;
+    }
+}

--- a/src/Routing/RouteExamples.php
+++ b/src/Routing/RouteExamples.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\ApiDocumenter\Routing;
+
+final class RouteExamples
+{
+    /**
+     * @var \LoyaltyCorp\ApiDocumenter\Routing\RouteExample[][][]
+     */
+    private $examples;
+
+    /**
+     * Constructor.
+     *
+     * @param \LoyaltyCorp\ApiDocumenter\Routing\RouteExample[] $examples
+     */
+    public function __construct(array $examples)
+    {
+        $sortedExamples = [];
+
+        foreach ($examples as $example) {
+            $method = $example->getMethod();
+            $path = $example->getPath();
+
+            if (\array_key_exists($method, $sortedExamples) === false) {
+                $sortedExamples[$method] = [];
+            }
+
+            if (\array_key_exists($path, $sortedExamples[$method]) === false) {
+                $sortedExamples[$method][$path] = [];
+            }
+
+            $sortedExamples[$method][$path][] = $example;
+        }
+
+        $this->examples = $sortedExamples;
+    }
+
+    /**
+     * Returns any examples for a method/path.
+     *
+     * @param string $method
+     * @param string $path
+     *
+     * @return \LoyaltyCorp\ApiDocumenter\Routing\RouteExample[]
+     */
+    public function getExamples(string $method, string $path): array
+    {
+        return $this->examples[$method][$path] ?? [];
+    }
+}

--- a/standards.cfg
+++ b/standards.cfg
@@ -1,5 +1,2 @@
 # Ensure code coverage is 100%
 PHPUNIT_COVERAGE_MINIMUM_LEVEL=100
-
-# Exclude copy paste detection on some paths
-PHPCPD_EXCLUDE_REGEX="#Routing\/RouteConverterTest#"

--- a/standards.cfg
+++ b/standards.cfg
@@ -1,2 +1,5 @@
 # Ensure code coverage is 100%
 PHPUNIT_COVERAGE_MINIMUM_LEVEL=100
+
+# Exclude copy paste detection on some paths
+PHPCPD_EXCLUDE_REGEX="#Routing\/RouteConverterTest#"

--- a/tests/Stubs/Documentation/GeneratorStub.php
+++ b/tests/Stubs/Documentation/GeneratorStub.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\ApiDocumenter\Stubs\Documentation;
 
 use LoyaltyCorp\ApiDocumenter\Documentation\Interfaces\GeneratorInterface;
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExamples;
 
 final class GeneratorStub implements GeneratorInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function generate(string $name, string $version): string
+    public function generate(string $name, string $version, ?RouteExamples $examples = null): string
     {
         return 'generated output';
     }

--- a/tests/Stubs/Routing/RouteToPathItemConverterStub.php
+++ b/tests/Stubs/Routing/RouteToPathItemConverterStub.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\ApiDocumenter\Stubs\Routing;
 
 use LoyaltyCorp\ApiDocumenter\Routing\Interfaces\RouteToPathItemConverterInterface;
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExamples;
 
 /**
  * @coversNothing
@@ -28,7 +29,7 @@ final class RouteToPathItemConverterStub implements RouteToPathItemConverterInte
     /**
      * {@inheritdoc}
      */
-    public function convert(array $routes): array
+    public function convert(array $routes, RouteExamples $examples): array
     {
         return $this->pathItems;
     }

--- a/tests/Unit/Routing/RouteConverterTest.php
+++ b/tests/Unit/Routing/RouteConverterTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Routing;
 
+use cebe\openapi\spec\Example;
 use cebe\openapi\spec\Operation;
 use cebe\openapi\spec\Parameter;
 use cebe\openapi\spec\PathItem;
@@ -10,6 +11,8 @@ use cebe\openapi\spec\RequestBody;
 use cebe\openapi\spec\Response as CebeResponse;
 use cebe\openapi\spec\Responses;
 use LoyaltyCorp\ApiDocumenter\Routing\Route;
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExample;
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExamples;
 use LoyaltyCorp\ApiDocumenter\Routing\RouteToPathItemConverter;
 use Tests\LoyaltyCorp\ApiDocumenter\Fixtures\Request;
 use Tests\LoyaltyCorp\ApiDocumenter\Fixtures\Response;
@@ -40,13 +43,8 @@ final class RouteConverterTest extends TestCase
             '/path/{param}',
             ['param']
         );
-        $route->setDescription('Description');
-        $route->setDeprecated(false);
-        $route->setRequestType(Request::class);
-        $route->setResponseType(Response::class);
-        $route->setSummary('Summary');
 
-        yield 'single path' => [
+        yield 'no data path' => [
             'routes' => [$route],
             'pathItems' => [
                 '/path/{param}' => new PathItem([
@@ -62,28 +60,6 @@ final class RouteConverterTest extends TestCase
                     ],
                     'get' => new Operation([
                         'deprecated' => false,
-                        'description' => 'Description',
-                        'requestBody' => new RequestBody([
-                            'content' => [
-                                'application/json' => [
-                                    'schema' => [
-                                        '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesRequest', // phpcs:ignore
-                                    ],
-                                ],
-                            ],
-                        ]),
-                        'responses' => new Responses([
-                            200 => new CebeResponse([
-                                'content' => [
-                                    'application/json' => [
-                                        'schema' => [
-                                            '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesResponse', // phpcs:ignore
-                                        ],
-                                    ],
-                                ],
-                            ]),
-                        ]),
-                        'summary' => 'Summary',
                     ]),
                 ]),
             ],
@@ -91,19 +67,19 @@ final class RouteConverterTest extends TestCase
 
         $route2 = new Route(
             TestController::class,
-            'methodWithMultipleParams',
-            'POST',
+            'method',
+            'GET',
             '/path/{param}',
             ['param']
         );
         $route2->setDescription('Description');
-        $route2->setDeprecated(true);
+        $route2->setDeprecated(false);
         $route2->setRequestType(Request::class);
         $route2->setResponseType(Response::class);
         $route2->setSummary('Summary');
 
-        yield 'double methods' => [
-            'routes' => [$route, $route2],
+        yield 'single path with multiple examples' => [
+            'routes' => [$route2],
             'pathItems' => [
                 '/path/{param}' => new PathItem([
                     'parameters' => [
@@ -125,6 +101,15 @@ final class RouteConverterTest extends TestCase
                                     'schema' => [
                                         '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesRequest', // phpcs:ignore
                                     ],
+                                    'examples' => [
+                                        new Example([
+                                            'summary' => 'example summary 1',
+                                            'description' => 'example description 1',
+                                            'value' => [
+                                                'request' => 'data',
+                                            ],
+                                        ]),
+                                    ],
                                 ],
                             ],
                         ]),
@@ -135,6 +120,148 @@ final class RouteConverterTest extends TestCase
                                         'schema' => [
                                             '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesResponse', // phpcs:ignore
                                         ],
+                                        'examples' => [
+                                            new Example([
+                                                'summary' => 'example summary 1',
+                                                'description' => 'example description 1',
+                                                'value' => [
+                                                    'response' => 'data',
+                                                ],
+                                            ]),
+                                        ],
+                                    ],
+                                ],
+                            ]),
+                            204 => new CebeResponse([
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesResponse', // phpcs:ignore
+                                        ],
+                                        'examples' => [],
+                                    ],
+                                ],
+                            ]),
+                        ]),
+                        'summary' => 'Summary',
+                    ]),
+                ]),
+            ],
+            'examples' => [
+                new RouteExample(
+                    'example description 1',
+                    'GET',
+                    '/path/{param}',
+                    '{"request": "data"}',
+                    '{"response": "data"}',
+                    200,
+                    'example summary 1'
+                ),
+                new RouteExample(
+                    'example description 2',
+                    'GET',
+                    '/path/{param}',
+                    null,
+                    null,
+                    204,
+                    'example summary 2'
+                ),
+            ],
+        ];
+
+        yield 'single path' => [
+            'routes' => [$route2],
+            'pathItems' => [
+                '/path/{param}' => new PathItem([
+                    'parameters' => [
+                        new Parameter([
+                            'in' => 'path',
+                            'name' => 'param',
+                            'required' => true,
+                            'schema' => [
+                                'type' => 'string',
+                            ],
+                        ]),
+                    ],
+                    'get' => new Operation([
+                        'deprecated' => false,
+                        'description' => 'Description',
+                        'requestBody' => new RequestBody([
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => [
+                                        '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesRequest', // phpcs:ignore
+                                    ],
+                                    'examples' => [],
+                                ],
+                            ],
+                        ]),
+                        'responses' => new Responses([
+                            200 => new CebeResponse([
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesResponse', // phpcs:ignore
+                                        ],
+                                        'examples' => [],
+                                    ],
+                                ],
+                            ]),
+                        ]),
+                        'summary' => 'Summary',
+                    ]),
+                ]),
+            ],
+        ];
+
+        $route3 = new Route(
+            TestController::class,
+            'methodWithMultipleParams',
+            'POST',
+            '/path/{param}',
+            ['param']
+        );
+        $route3->setDescription('Description');
+        $route3->setDeprecated(true);
+        $route3->setRequestType(Request::class);
+        $route3->setResponseType(Response::class);
+        $route3->setSummary('Summary');
+
+        yield 'double methods' => [
+            'routes' => [$route2, $route3],
+            'pathItems' => [
+                '/path/{param}' => new PathItem([
+                    'parameters' => [
+                        new Parameter([
+                            'in' => 'path',
+                            'name' => 'param',
+                            'required' => true,
+                            'schema' => [
+                                'type' => 'string',
+                            ],
+                        ]),
+                    ],
+                    'get' => new Operation([
+                        'deprecated' => false,
+                        'description' => 'Description',
+                        'requestBody' => new RequestBody([
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => [
+                                        '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesRequest', // phpcs:ignore
+                                    ],
+                                    'examples' => [],
+                                ],
+                            ],
+                        ]),
+                        'responses' => new Responses([
+                            200 => new CebeResponse([
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesResponse', // phpcs:ignore
+                                        ],
+                                        'examples' => [],
                                     ],
                                 ],
                             ]),
@@ -150,6 +277,7 @@ final class RouteConverterTest extends TestCase
                                     'schema' => [
                                         '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesRequest', // phpcs:ignore
                                     ],
+                                    'examples' => [],
                                 ],
                             ],
                         ]),
@@ -160,6 +288,7 @@ final class RouteConverterTest extends TestCase
                                         'schema' => [
                                             '$ref' => '#/components/schemas/TestsLoyaltyCorpApiDocumenterFixturesResponse', // phpcs:ignore
                                         ],
+                                        'examples' => [],
                                     ],
                                 ],
                             ]),
@@ -176,16 +305,17 @@ final class RouteConverterTest extends TestCase
      *
      * @param \LoyaltyCorp\ApiDocumenter\Routing\Route[] $routes
      * @param \cebe\openapi\spec\PathItem[] $pathItems
+     * @param \LoyaltyCorp\ApiDocumenter\Routing\RouteExample[]|null $examples
      *
      * @return void
      *
      * @dataProvider getTestData
      */
-    public function testConversion(array $routes, array $pathItems): void
+    public function testConversion(array $routes, array $pathItems, ?array $examples = null): void
     {
         $converter = new RouteToPathItemConverter();
 
-        $result = $converter->convert($routes);
+        $result = $converter->convert($routes, new RouteExamples($examples ?? []));
 
         self::assertEquals($pathItems, $result);
     }

--- a/tests/Unit/Routing/RouteConverterTest.php
+++ b/tests/Unit/Routing/RouteConverterTest.php
@@ -169,14 +169,27 @@ final class RouteConverterTest extends TestCase
             ],
         ];
 
+        $route3 = new Route(
+            TestController::class,
+            'method',
+            'GET',
+            '/other/{externalId}',
+            ['externalId']
+        );
+        $route3->setDescription('Other route');
+        $route3->setDeprecated(false);
+        $route3->setRequestType(Request::class);
+        $route3->setResponseType(Response::class);
+        $route3->setSummary('The real summary');
+
         yield 'single path' => [
-            'routes' => [$route2],
+            'routes' => [$route3],
             'pathItems' => [
-                '/path/{param}' => new PathItem([
+                '/other/{externalId}' => new PathItem([
                     'parameters' => [
                         new Parameter([
                             'in' => 'path',
-                            'name' => 'param',
+                            'name' => 'externalId',
                             'required' => true,
                             'schema' => [
                                 'type' => 'string',
@@ -185,7 +198,7 @@ final class RouteConverterTest extends TestCase
                     ],
                     'get' => new Operation([
                         'deprecated' => false,
-                        'description' => 'Description',
+                        'description' => 'Other route',
                         'requestBody' => new RequestBody([
                             'content' => [
                                 'application/json' => [
@@ -208,27 +221,27 @@ final class RouteConverterTest extends TestCase
                                 ],
                             ]),
                         ]),
-                        'summary' => 'Summary',
+                        'summary' => 'The real summary',
                     ]),
                 ]),
             ],
         ];
 
-        $route3 = new Route(
+        $route4 = new Route(
             TestController::class,
             'methodWithMultipleParams',
             'POST',
             '/path/{param}',
             ['param']
         );
-        $route3->setDescription('Description');
-        $route3->setDeprecated(true);
-        $route3->setRequestType(Request::class);
-        $route3->setResponseType(Response::class);
-        $route3->setSummary('Summary');
+        $route4->setDescription('Description');
+        $route4->setDeprecated(true);
+        $route4->setRequestType(Request::class);
+        $route4->setResponseType(Response::class);
+        $route4->setSummary('Summary');
 
         yield 'double methods' => [
-            'routes' => [$route2, $route3],
+            'routes' => [$route2, $route4],
             'pathItems' => [
                 '/path/{param}' => new PathItem([
                     'parameters' => [

--- a/tests/Unit/Routing/RouteExampleTest.php
+++ b/tests/Unit/Routing/RouteExampleTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Routing;
+
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExample;
+use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\ApiDocumenter\Routing\RouteExample
+ */
+final class RouteExampleTest extends TestCase
+{
+    /**
+     * Tests example methods.
+     *
+     * @return void
+     */
+    public function testMethods(): void
+    {
+        $example = new RouteExample(
+            'description',
+            'method',
+            '/path',
+            'request',
+            'response',
+            200,
+            'summary'
+        );
+
+        self::assertSame('description', $example->getDescription());
+        self::assertSame('method', $example->getMethod());
+        self::assertSame('/path', $example->getPath());
+        self::assertSame('request', $example->getRequestData());
+        self::assertSame('response', $example->getResponseData());
+        self::assertSame(200, $example->getResponseStatusCode());
+        self::assertSame('summary', $example->getSummary());
+    }
+}

--- a/tests/Unit/Routing/RouteExamplesTest.php
+++ b/tests/Unit/Routing/RouteExamplesTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\ApiDocumenter\Unit\Routing;
+
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExample;
+use LoyaltyCorp\ApiDocumenter\Routing\RouteExamples;
+use Tests\LoyaltyCorp\ApiDocumenter\TestCases\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\ApiDocumenter\Routing\RouteExamples
+ */
+final class RouteExamplesTest extends TestCase
+{
+    /**
+     * Tests example methods.
+     *
+     * @return void
+     */
+    public function testMethods(): void
+    {
+        $example = new RouteExample(
+            'description',
+            'post',
+            '/path',
+            'request',
+            'response',
+            200,
+            'summary'
+        );
+
+        $example2 = new RouteExample(
+            'description',
+            'get',
+            '/path',
+            'request',
+            'response',
+            200,
+            'summary'
+        );
+
+        $example3 = new RouteExample(
+            'description',
+            'put',
+            '/other',
+            'request',
+            'response',
+            200,
+            'summary'
+        );
+
+        $examples = new RouteExamples([$example, $example2, $example3]);
+
+        self::assertSame([$example], $examples->getExamples('post', '/path'));
+        self::assertSame([$example2], $examples->getExamples('get', '/path'));
+        self::assertSame([], $examples->getExamples('patch', '/other'));
+    }
+}


### PR DESCRIPTION
This adds the capability of supplying Examples to the route conversion process.

Example is an OpenAPI spec object: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject